### PR TITLE
GMCP Quest Panel - Client Side

### DIFF
--- a/public/css/panels.css
+++ b/public/css/panels.css
@@ -577,6 +577,28 @@
   color: #aaa;
 }
 
+/* ── Quest Panel ─────────────────────────────────────────────────────── */
+.quest-active { margin-bottom: 8px; }
+.quest-active-name { font-weight: 600; color: #e6edf3; margin-bottom: 2px; }
+.quest-active-desc { font-size: 12px; color: #8b949e; margin-bottom: 6px; }
+.quest-obj { margin-bottom: 4px; }
+.quest-obj-name { font-size: 12px; color: #c9d1d9; }
+.quest-obj-progress { display: flex; align-items: center; gap: 6px; }
+.quest-bar { flex: 1; height: 6px; background: #21262d; border-radius: 3px; overflow: hidden; }
+.quest-bar-sm { height: 4px; }
+.quest-bar-fill { height: 100%; background: #58a6ff; border-radius: 3px; transition: width 0.3s; }
+.quest-bar-done { background: #3fb950; }
+.quest-obj-count { font-size: 11px; color: #8b949e; min-width: 32px; text-align: right; }
+
+.quest-list { border-top: 1px solid #30363d; padding-top: 6px; }
+.quest-list-header { font-size: 11px; color: #484f58; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; }
+.quest-list-item { padding: 3px 0; }
+.quest-list-active .quest-list-name { color: #58a6ff; }
+.quest-list-done .quest-list-name { color: #3fb950; text-decoration: line-through; opacity: 0.7; }
+.quest-list-name { font-size: 12px; color: #c9d1d9; }
+.quest-list-info { display: flex; align-items: center; gap: 6px; }
+.quest-list-status { font-size: 11px; color: #8b949e; min-width: 60px; }
+
 /* ── Responsive ─────────────────────────────────────────────────────── */
 @media (max-width: 900px) {
   .dock-column { width: 200px; }

--- a/public/js/gmcp.js
+++ b/public/js/gmcp.js
@@ -52,7 +52,8 @@ export const gmcp = {
       'Darkwind.Window 1',
       'Darkwind.IDE 1',
       'Darkwind.MapData 1',
-      'Darkwind.Completion 1'
+      'Darkwind.Completion 1',
+      'Darkwind.Quests 1'
     ]);
     this.enabled = true;
   },

--- a/public/js/panel-defs.js
+++ b/public/js/panel-defs.js
@@ -15,6 +15,7 @@ export const PANEL_DEFS = {
   map:       { title: 'Map',       defaultDock: 'float', defaultOrder: 0,
                defaultFloatW: 400, defaultFloatH: 350,
                defaultSnapRight: true, defaultSnapTop: true },
+  quests:    { title: 'Quests',    defaultDock: 'right', defaultOrder: 3 },
 };
 
 export const PANEL_STORAGE_KEY = 'darkwind-panel-state';

--- a/public/js/panel-manager.js
+++ b/public/js/panel-manager.js
@@ -821,5 +821,44 @@ export const panelManager = {
       if (this.gmcpData.chat.length > 200) this.gmcpData.chat.shift();
       this._renderPanel('chat');
     });
+
+    gmcp.on('Darkwind.Quests.List', (data) => {
+      if (!this.gmcpData.quests) this.gmcpData.quests = {};
+      this.gmcpData.quests.list = data;
+      this._renderPanel('quests');
+    });
+
+    gmcp.on('Darkwind.Quests.Active', (data) => {
+      if (!this.gmcpData.quests) this.gmcpData.quests = {};
+      this.gmcpData.quests.active = data;
+      this._renderPanel('quests');
+    });
+
+    gmcp.on('Darkwind.Quests.Update', (data) => {
+      if (!this.gmcpData.quests) this.gmcpData.quests = {};
+      this.gmcpData.quests.lastUpdate = data;
+      // Update the active quest objective in-place if we have it
+      if (this.gmcpData.quests.active && Array.isArray(this.gmcpData.quests.active.objectives)) {
+        for (var i = 0; i < this.gmcpData.quests.active.objectives.length; i++) {
+          if (this.gmcpData.quests.active.objectives[i].name === data.objective) {
+            this.gmcpData.quests.active.objectives[i].current = data.current;
+            this.gmcpData.quests.active.objectives[i].required = data.required;
+            if (data.current >= data.required) {
+              this.gmcpData.quests.active.objectives[i].status = 'finished';
+            } else {
+              this.gmcpData.quests.active.objectives[i].status = 'started';
+            }
+            break;
+          }
+        }
+      }
+      this._renderPanel('quests');
+    });
+
+    gmcp.on('Darkwind.Quests.Complete', (data) => {
+      if (!this.gmcpData.quests) this.gmcpData.quests = {};
+      this.gmcpData.quests.lastComplete = data;
+      this._renderPanel('quests');
+    });
   }
 };

--- a/public/js/panel-renderers.js
+++ b/public/js/panel-renderers.js
@@ -466,4 +466,65 @@ export const panelRenderers = {
   map(bodyEl, _data) {
     renderMap(bodyEl);
   },
+
+  quests(bodyEl, data) {
+    if (!data) {
+      bodyEl.innerHTML = '<div class="placeholder">No quest data</div>';
+      return;
+    }
+
+    var html = '';
+    var active = data.active;
+    var list = data.list;
+
+    // Active quest detail
+    if (active && active.name) {
+      html += '<div class="quest-active">';
+      html += '<div class="quest-active-name">' + escHtml(active.name) + '</div>';
+      if (active.description) {
+        html += '<div class="quest-active-desc">' + escHtml(active.description) + '</div>';
+      }
+      if (Array.isArray(active.objectives)) {
+        for (var i = 0; i < active.objectives.length; i++) {
+          var obj = active.objectives[i];
+          var pct = obj.required > 0 ? Math.round((obj.current / obj.required) * 100) : 0;
+          if (pct > 100) pct = 100;
+          var done = obj.status === 'finished';
+          html += '<div class="quest-obj">';
+          html += '<div class="quest-obj-name">' + (done ? '&#10003; ' : '') + escHtml(obj.name) + '</div>';
+          html += '<div class="quest-obj-progress">';
+          html += '<div class="quest-bar"><div class="quest-bar-fill' + (done ? ' quest-bar-done' : '') + '" style="width:' + pct + '%"></div></div>';
+          html += '<span class="quest-obj-count">' + obj.current + '/' + obj.required + '</span>';
+          html += '</div></div>';
+        }
+      }
+      html += '</div>';
+    }
+
+    // Quest list
+    if (Array.isArray(list) && list.length > 0) {
+      html += '<div class="quest-list">';
+      html += '<div class="quest-list-header">Quests</div>';
+      for (var j = 0; j < list.length; j++) {
+        var q = list[j];
+        var isActive = q.active === 1;
+        var cls = 'quest-list-item';
+        if (isActive) cls += ' quest-list-active';
+        if (q.status === 'Finished') cls += ' quest-list-done';
+        var qPct = q.total > 0 ? Math.round((q.current / q.total) * 100) : 0;
+        if (qPct > 100) qPct = 100;
+        html += '<div class="' + cls + '">';
+        html += '<div class="quest-list-name">' + escHtml(q.name) + '</div>';
+        html += '<div class="quest-list-info">';
+        html += '<span class="quest-list-status">' + escHtml(q.status) + '</span>';
+        html += '<div class="quest-bar quest-bar-sm"><div class="quest-bar-fill' + (q.status === 'Finished' ? ' quest-bar-done' : '') + '" style="width:' + qPct + '%"></div></div>';
+        html += '</div></div>';
+      }
+      html += '</div>';
+    } else if (!active || !active.name) {
+      html += '<div class="placeholder">No quests accepted</div>';
+    }
+
+    bodyEl.innerHTML = html;
+  },
 };


### PR DESCRIPTION
Adds a Quests panel to the webclient that displays quest progress in real-time via GMCP.

## Changes
- **gmcp.js**: Add Darkwind.Quests 1 to Core.Supports.Set handshake
- **panel-defs.js**: Add quests panel definition (right dock, order 3)
- **panel-manager.js**: GMCP handlers for Darkwind.Quests.List/Active/Update/Complete with in-place objective updates
- **panel-renderers.js**: Quest panel renderer with active quest detail, progress bars, and quest list
- **panels.css**: Quest panel styling